### PR TITLE
Scala 2.13.0-m4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ jdk:
 scala:
    - 2.10.6
    - 2.11.8
-   - 2.12.4
+   - 2.12.6
+   - 2.13.0-M4
 matrix:
   exclude:
     - jdk: oraclejdk7
-      scala: 2.12.4
+      scala: 2.12.6
+    - jdk: oraclejdk7
+      scala: 2.13.0-M4

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ version := "1.0.5-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.4", "2.13.0-M4")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.6", "2.13.0-M4")
 
 organizationHomepage in ThisBuild := Some(url("http://swagger.io"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ version := "1.0.5-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.4")
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.4", "2.13.0-M4")
 
 organizationHomepage in ThisBuild := Some(url("http://swagger.io"))
 
@@ -23,9 +23,10 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 libraryDependencies ++= Seq(
-  "io.swagger" % "swagger-core" % "1.5.18",
-  "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.5",
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
+  "io.swagger" % "swagger-core" % "1.5.20",
+  "org.scalatest" %% "scalatest" % "3.0.6-SNAP1" % "test",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.6",
   "junit" % "junit" % "4.12" % "test"
 )
 


### PR DESCRIPTION
the scala 2.13.0-M4 version of jackson-module-scala:2.9.6 removed the scala-reflect dependency